### PR TITLE
REX API Integration

### DIFF
--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -60,8 +60,8 @@ export function Game({
             Please choose a Pog from your wallet to play with.
           </div>
         )}
-        {gameState == FlipGameState.PogPicked ||
-          (gameState == FlipGameState.GameStarted && (
+        {(gameState == FlipGameState.PogPicked ||
+          gameState == FlipGameState.GameStarted) && (
             <div className="mt-8">
               {playerPog && (
                 <PogView
@@ -71,7 +71,7 @@ export function Game({
                 />
               )}
             </div>
-          ))}
+          )}
       </div>
       {gameState == FlipGameState.PogPicked && (
         <div className="text-center">
@@ -98,7 +98,7 @@ export function Game({
         </div>
       )}
 
-      {FlipGameState.GameStarted && (
+      {gameState == FlipGameState.GameStarted && (
         <div className="text-center">
           <div className="flex flex-col h-full justify-center">
             <div>

--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -73,31 +73,54 @@ export function Game({
             </div>
           ))}
       </div>
-      {gameState == FlipGameState.PogPicked ||
-        (gameState == FlipGameState.GameStarted && (
-          <div className="text-center">
-            <div className="flex flex-col h-full justify-center">
+      {gameState == FlipGameState.PogPicked && (
+        <div className="text-center">
+          <div className="flex flex-col h-full justify-center">
+            <div>
+              <button
+                className="btn btn-lg bg-primary hover:bg-primary-focus text-primary-content border-primary-focus border-4 h-36 w-36 rounded-full m-10"
+                onClick={() => {
+                  onPlayGame();
+                }}
+              >
+                FLIP!
+              </button>
+              <div className="text-xl pl-5 pr-5 pb-10">
+                You have a 50% chance of losing your Pog and 50% of earning one
+                from Pogman!
+              </div>
               <div>
-                <button
-                  className="btn btn-lg bg-primary hover:bg-primary-focus text-primary-content border-primary-focus border-4 h-36 w-36 rounded-full m-10"
-                  onClick={() => {
-                    onPlayGame();
-                  }}
-                >
-                  FLIP!
-                </button>
-                <div className="text-xl pl-5 pr-5 pb-10">
-                  You have a 50% change of losing your Pog, or earning one from
-                  Pogman!
-                </div>
-                <div>
-                  Pressing Flip will transfer your Pog NFT out of your wallet to
-                  start the game.
-                </div>
+                Pressing Flip will transfer your Pog NFT out of your wallet to
+                start the game.
               </div>
             </div>
           </div>
-        ))}
+        </div>
+      )}
+
+      {FlipGameState.GameStarted && (
+        <div className="text-center">
+          <div className="flex flex-col h-full justify-center">
+            <div>
+              <button
+                className="btn btn-lg bg-primary hover:bg-primary-focus text-primary-content border-primary-focus border-4 h-36 w-36 rounded-full m-10"
+                onClick={() => {
+                  onPlayGame();
+                }}
+              >
+                FLIP!
+              </button>
+              <div className="text-xl pl-5 pr-5 pb-10">
+                You have a 50% chance of losing your Pog and 50% of earning one
+                from Pogman!
+              </div>
+              <div>
+                Your Pog has been moved out of your wallet and is now in escrow.
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -8,12 +8,14 @@ export function Game({
   winningPog,
   onPlayGame,
   onRestartGame,
+  isFlipping,
 }: {
   gameState: FlipGameState;
   playerPog: PogNFT | null;
   winningPog: PogMintAddress | null;
   onPlayGame: () => {};
   onRestartGame: () => {};
+  isFlipping: boolean;
 }) {
   return (
     <div className="flex flex-col w-full sm:flex-row">
@@ -79,6 +81,7 @@ export function Game({
             <div>
               <button
                 className="btn btn-lg bg-primary hover:bg-primary-focus text-primary-content border-primary-focus border-4 h-36 w-36 rounded-full m-10"
+                disabled={isFlipping}
                 onClick={() => {
                   onPlayGame();
                 }}
@@ -104,6 +107,7 @@ export function Game({
             <div>
               <button
                 className="btn btn-lg bg-primary hover:bg-primary-focus text-primary-content border-primary-focus border-4 h-36 w-36 rounded-full m-10"
+                disabled={isFlipping}
                 onClick={() => {
                   onPlayGame();
                 }}

--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -60,40 +60,44 @@ export function Game({
             Please choose a Pog from your wallet to play with.
           </div>
         )}
-        {gameState == FlipGameState.PogPicked && (
-          <div className="mt-8">
-            {playerPog && (
-              <PogView
-                name={playerPog.name}
-                mintAddress={playerPog.mintAddress}
-                imageUrl={playerPog.imageUrl}
-              />
-            )}
-          </div>
-        )}
+        {gameState == FlipGameState.PogPicked ||
+          (gameState == FlipGameState.GameStarted && (
+            <div className="mt-8">
+              {playerPog && (
+                <PogView
+                  name={playerPog.name}
+                  mintAddress={playerPog.mintAddress}
+                  imageUrl={playerPog.imageUrl}
+                />
+              )}
+            </div>
+          ))}
       </div>
-      {gameState == FlipGameState.PogPicked && (
-        <div className="text-center">
-          <div className="flex flex-col h-full justify-center">
-            <div>
-              <button
-                disabled={gameState !== FlipGameState.PogPicked}
-                className="btn btn-lg bg-primary hover:bg-primary-focus text-primary-content border-primary-focus border-4 h-36 w-36 rounded-full m-10"
-                onClick={() => {
-                  onPlayGame();
-                }}
-              >
-                FLIP!
-              </button>
-              <div className="text-xl pl-5 pr-5 pb-10">
-                You have a 50% change of losing your Pog, or earning one from
-                Pogman!
+      {gameState == FlipGameState.PogPicked ||
+        (gameState == FlipGameState.GameStarted && (
+          <div className="text-center">
+            <div className="flex flex-col h-full justify-center">
+              <div>
+                <button
+                  className="btn btn-lg bg-primary hover:bg-primary-focus text-primary-content border-primary-focus border-4 h-36 w-36 rounded-full m-10"
+                  onClick={() => {
+                    onPlayGame();
+                  }}
+                >
+                  FLIP!
+                </button>
+                <div className="text-xl pl-5 pr-5 pb-10">
+                  You have a 50% change of losing your Pog, or earning one from
+                  Pogman!
+                </div>
+                <div>
+                  Pressing Flip will transfer your Pog NFT out of your wallet to
+                  start the game.
+                </div>
               </div>
-              <div>Pressing Flip will transfer your Pog NFT out of your wallet to start the game.</div>
             </div>
           </div>
-        </div>
-      )}
+        ))}
     </div>
   );
 }

--- a/lib/flipgame.ts
+++ b/lib/flipgame.ts
@@ -10,6 +10,7 @@ const POGFLIP_ESCROW = '2HfWgU9nkwdBLFJ7s1UW4PBwgkgB16h7boXyGKNBZypB';
 const REX_API_BASEURL = 'https://api.r3x.tech';
 
 import * as web3 from '@solana/web3.js';
+import axios from 'axios';
 import type { WalletAdapterProps } from '@solana/wallet-adapter-base';
 import {
   getAssociatedTokenAddress,
@@ -159,19 +160,22 @@ export class FlipGame {
     const to = new web3.PublicKey(POGFLIP_ESCROW);
     const toTokenAccount = await getAssociatedTokenAddress(mintPublicKey, to);
 
-    const result = await fetch(
-      `${REX_API_BASEURL}/pogs/transfer-pog-to-escrow`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          userwalletaddress: publicKey.toString(),
-          usertokenaddress: toTokenAccount.toString(),
-        }),
-      }
-    );
+    console.log({
+      userwalletaddress: publicKey.toString(),
+      usertokenaddress: toTokenAccount.toString(),
+    });
+
+    const result = await axios({
+      method: 'post',
+      url: `${REX_API_BASEURL}/pogs/transfer-pog-to-escrow`,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: {
+        userwalletaddress: publicKey.toString(),
+        usertokenaddress: toTokenAccount.toString(),
+      },
+    });
 
     console.log('RESULT', result);
   }

--- a/lib/flipgame.ts
+++ b/lib/flipgame.ts
@@ -148,21 +148,30 @@ export class FlipGame {
     }
   }
 
-  async stepTwoTransferPogmanPog({ playerPog }: { playerPog: PogNFT }) {
+  async stepTwoTransferPogmanPog({
+    playerPog,
+    publicKey,
+  }: {
+    playerPog: PogNFT;
+    publicKey: web3.PublicKey;
+  }) {
     const mintPublicKey = new web3.PublicKey(playerPog.mintAddress);
     const to = new web3.PublicKey(POGFLIP_ESCROW);
     const toTokenAccount = await getAssociatedTokenAddress(mintPublicKey, to);
 
-    const result = await fetch(`${REX_API_BASEURL}/pogs/transfer-pog-to-escrow`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        network: 'devnet',
-        tokenAddress: toTokenAccount.toString(),
-      }),
-    });
+    const result = await fetch(
+      `${REX_API_BASEURL}/pogs/transfer-pog-to-escrow`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          userwalletaddress: publicKey.toString(),
+          usertokenaddress: toTokenAccount.toString(),
+        }),
+      }
+    );
 
     console.log('RESULT', result);
   }

--- a/lib/flipgame.ts
+++ b/lib/flipgame.ts
@@ -153,7 +153,7 @@ export class FlipGame {
     const to = new web3.PublicKey(POGFLIP_ESCROW);
     const toTokenAccount = await getAssociatedTokenAddress(mintPublicKey, to);
 
-    const result = await fetch(`${REX_API_BASEURL}/nft/transfer/to-escrow`, {
+    const result = await fetch(`${REX_API_BASEURL}/pogs/transfer-pog-to-escrow`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/lib/flipgame.ts
+++ b/lib/flipgame.ts
@@ -206,7 +206,7 @@ export class FlipGame {
 
     const result = await axios({
       method: 'post',
-      url: `${REX_API_BASEURL}/pogs/transfer-pog-from-escrow`,
+      url: `${REX_API_BASEURL}/pogs/transfer-from-escrow`,
       headers: {
         'Content-Type': 'application/json',
       },
@@ -219,14 +219,25 @@ export class FlipGame {
 
     console.log('Step 3 RESULT', result);
 
-    if (result.data) {
+    let winningPogMintAddress: string | null = null;
+
+    interface OutcomeResult {
+      outcome: boolean;
+      usertokenaddress: string;
+      tx1: string;
+    }
+
+    const data = result.data as OutcomeResult;
+
+    if (data.outcome) {
       console.log('WINNER');
+      winningPogMintAddress = data.usertokenaddress;
     } else {
       console.log('LOSER');
     }
 
     return {
-      winningPogMintAddress: null,
+      winningPogMintAddress,
     };
   }
 }

--- a/lib/flipgame.ts
+++ b/lib/flipgame.ts
@@ -206,7 +206,7 @@ export class FlipGame {
 
     const result = await axios({
       method: 'post',
-      url: `${REX_API_BASEURL}/pogs/transfer-from-escrow`,
+      url: `${REX_API_BASEURL}/pogs/transfer-pog-from-escrow`,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/lib/flipgame.ts
+++ b/lib/flipgame.ts
@@ -7,6 +7,7 @@ Game loop:
 */
 
 const POGFLIP_ESCROW = '2HfWgU9nkwdBLFJ7s1UW4PBwgkgB16h7boXyGKNBZypB';
+const REX_API_BASEURL = 'https://api.r3x.tech';
 
 import * as web3 from '@solana/web3.js';
 import type { WalletAdapterProps } from '@solana/wallet-adapter-base';
@@ -18,7 +19,7 @@ import {
 
 import { PogNFT } from './nft';
 
-export type PogMintAddress = string | null;
+export type PogMintAddress = string;
 
 export enum FlipGameState {
   AwaitPlayerPog,
@@ -147,7 +148,24 @@ export class FlipGame {
     }
   }
 
-  async stepTwoTransferPogmanPog() {}
+  async stepTwoTransferPogmanPog({ playerPog }: { playerPog: PogNFT }) {
+    const mintPublicKey = new web3.PublicKey(playerPog.mintAddress);
+    const to = new web3.PublicKey(POGFLIP_ESCROW);
+    const toTokenAccount = await getAssociatedTokenAddress(mintPublicKey, to);
+
+    const result = await fetch(`${REX_API_BASEURL}/nft/transfer/to-escrow`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        network: 'devnet',
+        tokenAddress: toTokenAccount.toString(),
+      }),
+    });
+
+    console.log('RESULT', result);
+  }
 
   async stepThreeResults({
     playerPogMintAddress,

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@solana/wallet-adapter-wallets": "^0.19.1",
     "@solana/web3.js": "^1.63.1",
     "@testing-library/dom": "^8.19.0",
+    "axios": "^1.1.3",
     "bs58": "^5.0.0",
     "daisyui": "^2.20.0",
     "next": "12.3.1",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,7 +36,7 @@ const Home: NextPage = () => {
   async function initGame() {
     setWinningPog(null);
     const pog = await game.getPogInProgress({
-      browserStorage: window.sessionStorage,
+      browserStorage: window.localStorage,
     });
     console.log('POG IN PROGRESS', pog);
     if (pog) {
@@ -69,7 +69,7 @@ const Home: NextPage = () => {
 
       if (
         !(await game.getPogInProgress({
-          browserStorage: window.sessionStorage,
+          browserStorage: window.localStorage,
         }))
       ) {
         await game.stepOneTransferPlayerPog({
@@ -77,11 +77,11 @@ const Home: NextPage = () => {
           publicKey,
           sendTransaction,
           playerPog,
-          browserStorage: window.sessionStorage,
+          browserStorage: window.localStorage,
         });
       }
 
-      await game.stepTwoTransferPogmanPog({ playerPog });
+      await game.stepTwoTransferPogmanPog({ playerPog, publicKey });
 
       const result = await game.stepThreeResults({
         playerPogMintAddress: playerPog.mintAddress,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -86,12 +86,11 @@ const Home: NextPage = () => {
       const result = await game.stepThreeResults({
         playerPogMintAddress: playerPog.mintAddress,
       });
-      setWinningPog(result.winningPogMintAddress);
 
-      // TODO: If game is over then clear it!
-      //game.clearPogInProgress()
-
-      setGameState(FlipGameState.GameFinished);
+      // TODO: When game is officially over
+      // setWinningPog(result.winningPogMintAddress);
+      // setGameState(FlipGameState.GameFinished);
+      // game.clearPogInProgress()
     }
   }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -81,7 +81,7 @@ const Home: NextPage = () => {
         });
       }
 
-      await game.stepTwoTransferPogmanPog();
+      await game.stepTwoTransferPogmanPog({ playerPog });
 
       const result = await game.stepThreeResults({
         playerPogMintAddress: playerPog.mintAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,6 +2473,15 @@ axios@^0.21.0:
   dependencies:
     follow-redirects "^1.14.0"
 
+axios@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.1.3.tgz#8274250dada2edf53814ed7db644b9c2866c1e35"
+  integrity sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -3985,7 +3994,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.14.0:
+follow-redirects@^1.14.0, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -5884,6 +5893,11 @@ prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
- [x] Refactor UI to support 3 API calls in client (to replace `/pogflip` API that was timing out)
- [x] Support resumable game in case browser crashes after player transfers their Pog into the game's escrow wallet. How it works:
  - pog data is persisted in the browser after successful transfer to escrow
  - if browser crashes and player reloads, game will resume with that same Pog and not ask player to escrow another Pog and lose their first one.
  - player will see `Flip` button again and pressing it will not escrow a new Pog but rather restore the game with the Pog that was already escrowed.
  - this feature needed since no way to know if Pog was already escrowed without either an authoritative server or game state on blockchain)
- [x] disable "flip" button while game is in progress
- [x] Integrate with REX protocol to pick a random Pogman Pog from the pool to start the game (`/nft/transfer/to-escrow`)
- [ ] Integrate with REX protocol to run the game logic and process outcome and winning Pog (`/nft/transfer/from-escrow`)